### PR TITLE
Ajouter fonctionnalité de modifier les attributs

### DIFF
--- a/pkg/xixo/calback_test.go
+++ b/pkg/xixo/calback_test.go
@@ -102,3 +102,30 @@ func mapCallbackAttributs(dict map[string]string) (map[string]string, error) {
 
 	return dict, nil
 }
+
+func TestMapCallbackWithAttributsParentAndChilds(t *testing.T) {
+	t.Parallel()
+
+	element1 := createTreeWithAttributParent()
+	//nolint
+	assert.Equal(t, "<root type=\"foo\">\n  <element1 age=\"22\" sex=\"male\">Hello world !</element1>\n  <element2>Contenu2 </element2>\n</root>", element1.String())
+
+	editedElement1, err := xixo.XMLElementToMapCallback(mapCallbackAttributsWithParent)(element1)
+	assert.Nil(t, err)
+
+	text := editedElement1.FirstChild().InnerText
+
+	assert.Equal(t, "newChildContent", text)
+
+	//nolint
+	assert.Equal(t, "<root type=\"bar\">\n  <element1 age=\"50\" sex=\"male\">newChildContent</element1>\n  <element2 age=\"25\">Contenu2 </element2>\n</root>", editedElement1.String())
+}
+
+func mapCallbackAttributsWithParent(dict map[string]string) (map[string]string, error) {
+	dict["@type"] = "bar"
+	dict["element1@age"] = "50"
+	dict["element1"] = "newChildContent"
+	dict["element2@age"] = "25"
+
+	return dict, nil
+}

--- a/pkg/xixo/calback_test.go
+++ b/pkg/xixo/calback_test.go
@@ -81,9 +81,9 @@ func TestBadJsonCallback(t *testing.T) {
 func TestMapCallbackWithAttributs(t *testing.T) {
 	t.Parallel()
 
-	element1 := createTree()
+	element1 := createTreeWithAttribut()
 	//nolint
-	assert.Equal(t, "<root>\n  <element1 age='22'>Hello world !</element1>\n  <element2>Contenu2 </element2>\n</root>", element1.String())
+	assert.Equal(t, "<root>\n  <element1 age=\"22\">Hello world !</element1>\n  <element2>Contenu2 </element2>\n</root>", element1.String())
 
 	editedElement1, err := xixo.XMLElementToMapCallback(mapCallbackAttributs)(element1)
 	assert.Nil(t, err)
@@ -93,7 +93,7 @@ func TestMapCallbackWithAttributs(t *testing.T) {
 	assert.Equal(t, "newChildContent", text)
 
 	//nolint
-	assert.Equal(t, "<root>\n  <element1 age='50'>newChildContent</element1>\n  <element2>Contenu2 </element2>\n</root>", editedElement1.String())
+	assert.Equal(t, "<root>\n  <element1 age=\"50\">newChildContent</element1>\n  <element2>Contenu2 </element2>\n</root>", editedElement1.String())
 }
 
 func mapCallbackAttributs(dict map[string]string) (map[string]string, error) {

--- a/pkg/xixo/calback_test.go
+++ b/pkg/xixo/calback_test.go
@@ -77,3 +77,28 @@ func TestBadJsonCallback(t *testing.T) {
 
 	assert.NotNil(t, err)
 }
+
+func TestMapCallbackWithAttributs(t *testing.T) {
+	t.Parallel()
+
+	element1 := createTree()
+	//nolint
+	assert.Equal(t, "<root>\n  <element1 age='22'>Hello world !</element1>\n  <element2>Contenu2 </element2>\n</root>", element1.String())
+
+	editedElement1, err := xixo.XMLElementToMapCallback(mapCallbackAttributs)(element1)
+	assert.Nil(t, err)
+
+	text := editedElement1.FirstChild().InnerText
+
+	assert.Equal(t, "newChildContent", text)
+
+	//nolint
+	assert.Equal(t, "<root>\n  <element1 age='50'>newChildContent</element1>\n  <element2>Contenu2 </element2>\n</root>", editedElement1.String())
+}
+
+func mapCallbackAttributs(dict map[string]string) (map[string]string, error) {
+	dict["element1@age"] = "50"
+	dict["element1"] = "newChildContent"
+
+	return dict, nil
+}

--- a/pkg/xixo/calback_test.go
+++ b/pkg/xixo/calback_test.go
@@ -8,8 +8,10 @@ import (
 	"github.com/youen/xixo/pkg/xixo"
 )
 
+const newChildContent = "newChildContent"
+
 func mapCallback(dict map[string]string) (map[string]string, error) {
-	dict["element1"] = "newChildContent"
+	dict["element1"] = newChildContent
 
 	return dict, nil
 }
@@ -41,7 +43,7 @@ func jsonCallback(source string) (string, error) {
 		return "", err
 	}
 
-	dict["element1"] = "newChildContent"
+	dict["element1"] = newChildContent
 
 	result, err := json.Marshal(dict)
 
@@ -98,7 +100,7 @@ func TestMapCallbackWithAttributs(t *testing.T) {
 
 func mapCallbackAttributs(dict map[string]string) (map[string]string, error) {
 	dict["element1@age"] = "50"
-	dict["element1"] = "newChildContent"
+	dict["element1"] = newChildContent
 
 	return dict, nil
 }
@@ -124,7 +126,7 @@ func TestMapCallbackWithAttributsParentAndChilds(t *testing.T) {
 func mapCallbackAttributsWithParent(dict map[string]string) (map[string]string, error) {
 	dict["@type"] = "bar"
 	dict["element1@age"] = "50"
-	dict["element1"] = "newChildContent"
+	dict["element1"] = newChildContent
 	dict["element2@age"] = "25"
 
 	return dict, nil

--- a/pkg/xixo/callback.go
+++ b/pkg/xixo/callback.go
@@ -1,6 +1,9 @@
 package xixo
 
-import "encoding/json"
+import (
+	"encoding/json"
+	"regexp"
+)
 
 type Callback func(*XMLElement) (*XMLElement, error)
 
@@ -8,10 +11,15 @@ type CallbackMap func(map[string]string) (map[string]string, error)
 
 type CallbackJSON func(string) (string, error)
 
+type Attributs struct {
+	Attr    string
+	AttrVal string
+}
+
 func XMLElementToMapCallback(callback CallbackMap) Callback {
 	result := func(xmlElement *XMLElement) (*XMLElement, error) {
 		dict := map[string]string{}
-
+		var AttributsList map[string][]Attributs
 		for name, child := range xmlElement.Childs {
 			dict[name] = child[0].InnerText
 		}
@@ -26,7 +34,36 @@ func XMLElementToMapCallback(callback CallbackMap) Callback {
 			return nil, err
 		}
 
+		// check dict[name] include "@"
+		re := regexp.MustCompile("@")
+		for key, value := range dict {
+			if re.MatchString(key) {
+				// if include, use regexp to get element:before@ ,attr:after@
+				parts := re.Split(key, 2)
+				tagName := parts[0]
+				newAttribut := Attributs{Attr: parts[1], AttrVal: value}
+				if existingElement, ok := AttributsList[tagName]; ok {
+					// if key already in attributs
+					existingElement = append(existingElement, newAttribut)
+					AttributsList[tagName] = existingElement
+				} else {
+					// if key not in attributs yet
+					AttributsList[tagName] = []Attributs{newAttribut}
+				}
+			}
+		}
+
 		for _, child := range children {
+			// if attrlist, ok := AttributsList[child.Name]; ok {
+			// 	if child.Attrs == nil {
+
+			// 	}
+			// 	child.InnerText = value
+			// }
+			// if xmlElement.Attrs == nil
+
+			// creat one
+			// apprend {} to Attrs
 			if value, ok := dict[child.Name]; ok {
 				child.InnerText = value
 			}

--- a/pkg/xixo/element.go
+++ b/pkg/xixo/element.go
@@ -99,8 +99,8 @@ func (n *XMLElement) String() string {
 
 	attributes := n.Name + " "
 
-	for _, attr := range n.attrs {
-		attributes += fmt.Sprintf("%s=\"%s\" ", attr.name, attr.value)
+	for key, value := range n.Attrs {
+		attributes += fmt.Sprintf("%s=\"%s\" ", key, value)
 	}
 
 	attributes = strings.Trim(attributes, " ")

--- a/pkg/xixo/element.go
+++ b/pkg/xixo/element.go
@@ -8,6 +8,7 @@ import (
 type XMLElement struct {
 	Name      string
 	Attrs     map[string]string
+	AttrKeys  []string
 	InnerText string
 	Childs    map[string][]XMLElement
 	Err       error
@@ -112,10 +113,11 @@ func (n *XMLElement) String() string {
 		n.Name)
 }
 
-func (n *XMLElement) AddAttribut(name string, value string) {
+func (n *XMLElement) AddAttribute(name string, value string) {
 	if n.Attrs == nil {
 		n.Attrs = make(map[string]string)
 	}
+
 	n.Attrs[name] = value
 }
 
@@ -123,6 +125,7 @@ func NewXMLElement() *XMLElement {
 	return &XMLElement{
 		Name:      "",
 		Attrs:     map[string]string{},
+		AttrKeys:  make([]string, 0),
 		InnerText: "",
 		Childs:    map[string][]XMLElement{},
 		Err:       nil,

--- a/pkg/xixo/element.go
+++ b/pkg/xixo/element.go
@@ -35,6 +35,10 @@ func (n *XMLElement) SelectElement(exp string) (*XMLElement, error) {
 }
 
 func (n *XMLElement) FirstChild() *XMLElement {
+	if n.childs == nil {
+		return nil
+	}
+
 	if len(n.childs) > 0 {
 		return n.childs[0]
 	}
@@ -106,4 +110,26 @@ func (n *XMLElement) String() string {
 		n.InnerText,
 		xmlChilds,
 		n.Name)
+}
+
+func (n *XMLElement) AddAttribut(name string, value string) {
+	if n.Attrs == nil {
+		n.Attrs = make(map[string]string)
+	}
+	n.Attrs[name] = value
+}
+
+func NewXMLElement(name string, attrs map[string]string) *XMLElement {
+	return &XMLElement{
+		Name:      name,
+		Attrs:     attrs,
+		InnerText: "",
+		Childs:    map[string][]XMLElement{},
+		Err:       nil,
+		childs:    []*XMLElement{},
+		parent:    nil,
+		attrs:     []*xmlAttr{},
+		localName: "",
+		prefix:    "",
+	}
 }

--- a/pkg/xixo/element.go
+++ b/pkg/xixo/element.go
@@ -99,9 +99,8 @@ func (n *XMLElement) String() string {
 	}
 
 	attributes := n.Name + " "
-
-	for key, value := range n.Attrs {
-		attributes += fmt.Sprintf("%s=\"%s\" ", key, value)
+	for _, key := range n.AttrKeys {
+		attributes += fmt.Sprintf("%s=\"%s\" ", key, n.Attrs[key])
 	}
 
 	attributes = strings.Trim(attributes, " ")
@@ -117,7 +116,12 @@ func (n *XMLElement) AddAttribute(name string, value string) {
 	if n.Attrs == nil {
 		n.Attrs = make(map[string]string)
 	}
-
+	// if name don't exsite in Attrs yet
+	if _, ok := n.Attrs[name]; !ok {
+		// Add un key in slice to keep the order of attributes
+		n.AttrKeys = append(n.AttrKeys, name)
+	}
+	// change the value of attribute
 	n.Attrs[name] = value
 }
 

--- a/pkg/xixo/element.go
+++ b/pkg/xixo/element.go
@@ -119,10 +119,10 @@ func (n *XMLElement) AddAttribut(name string, value string) {
 	n.Attrs[name] = value
 }
 
-func NewXMLElement(name string, attrs map[string]string) *XMLElement {
+func NewXMLElement() *XMLElement {
 	return &XMLElement{
-		Name:      name,
-		Attrs:     attrs,
+		Name:      "",
+		Attrs:     map[string]string{},
 		InnerText: "",
 		Childs:    map[string][]XMLElement{},
 		Err:       nil,

--- a/pkg/xixo/element_test.go
+++ b/pkg/xixo/element_test.go
@@ -97,9 +97,9 @@ func TestCreatNewXMLElement(t *testing.T) {
 
 	var root *xixo.XMLElement
 	name := "root"
-	attrs := map[string]string{}
 	parser := xixo.NewXMLParser(bytes.NewBufferString(rootXML), io.Discard).EnableXpath()
-	root = xixo.NewXMLElement(name, attrs)
+	root = xixo.NewXMLElement()
+	root.Name = name
 	err := parser.Stream()
 	assert.Nil(t, err)
 	expected := `<root></root>`
@@ -110,21 +110,13 @@ func TestCreatNewXMLElement(t *testing.T) {
 func TestAddAttributsShouldSaved(t *testing.T) {
 	t.Parallel()
 
-	rootXML := `
-	<root>
-	</root>`
-
 	var root *xixo.XMLElement
 
 	name := "root"
-	attrs := map[string]string{}
-	parser := xixo.NewXMLParser(bytes.NewBufferString(rootXML), io.Discard).EnableXpath()
-	root = xixo.NewXMLElement(name, attrs)
+	root = xixo.NewXMLElement()
+	root.Name = name
 
 	root.AddAttribut("foo", "bar")
-	err := parser.Stream()
-	assert.Nil(t, err)
-	expected := `<root foo="bar"></root>`
-
-	assert.Equal(t, expected, root.String())
+	expected := map[string]string{"foo": "bar"}
+	assert.Equal(t, root.Attrs, expected)
 }

--- a/pkg/xixo/element_test.go
+++ b/pkg/xixo/element_test.go
@@ -87,3 +87,44 @@ func TestElementStringShouldReturnXMLWithSameOrder(t *testing.T) {
 
 	assert.Equal(t, rootXML, root.String())
 }
+
+func TestCreatNewXMLElement(t *testing.T) {
+	t.Parallel()
+
+	rootXML := `
+	<root>
+	</root>`
+
+	var root *xixo.XMLElement
+	name := "root"
+	attrs := map[string]string{}
+	parser := xixo.NewXMLParser(bytes.NewBufferString(rootXML), io.Discard).EnableXpath()
+	root = xixo.NewXMLElement(name, attrs)
+	err := parser.Stream()
+	assert.Nil(t, err)
+	expected := `<root></root>`
+
+	assert.Equal(t, expected, root.String())
+}
+
+func TestAddAttributsShouldSaved(t *testing.T) {
+	t.Parallel()
+
+	rootXML := `
+	<root>
+	</root>`
+
+	var root *xixo.XMLElement
+
+	name := "root"
+	attrs := map[string]string{}
+	parser := xixo.NewXMLParser(bytes.NewBufferString(rootXML), io.Discard).EnableXpath()
+	root = xixo.NewXMLElement(name, attrs)
+
+	root.AddAttribut("foo", "bar")
+	err := parser.Stream()
+	assert.Nil(t, err)
+	expected := `<root foo="bar"></root>`
+
+	assert.Equal(t, expected, root.String())
+}

--- a/pkg/xixo/element_test.go
+++ b/pkg/xixo/element_test.go
@@ -9,6 +9,8 @@ import (
 	"github.com/youen/xixo/pkg/xixo"
 )
 
+const parentTag = "root"
+
 func createTree() *xixo.XMLElement {
 	rootXML := `
 	<root>
@@ -144,12 +146,15 @@ func TestCreatNewXMLElement(t *testing.T) {
 	</root>`
 
 	var root *xixo.XMLElement
-	name := "root"
+
+	name := parentTag
 	parser := xixo.NewXMLParser(bytes.NewBufferString(rootXML), io.Discard).EnableXpath()
 	root = xixo.NewXMLElement()
 	root.Name = name
 	err := parser.Stream()
+
 	assert.Nil(t, err)
+
 	expected := `<root></root>`
 
 	assert.Equal(t, expected, root.String())
@@ -160,23 +165,24 @@ func TestAddAttributsShouldSaved(t *testing.T) {
 
 	var root *xixo.XMLElement
 
-	name := "root"
+	name := parentTag
 	root = xixo.NewXMLElement()
 	root.Name = name
 
-	root.AddAttribut("foo", "bar")
+	root.AddAttribute("foo", "bar")
+
 	expected := map[string]string{"foo": "bar"}
+
 	assert.Equal(t, root.Attrs, expected)
 }
 
 func TestAddAttributsShouldInOutputWithString(t *testing.T) {
 	t.Parallel()
 
-	var root *xixo.XMLElement
-	root = xixo.NewXMLElement()
-	root.Name = "root"
+	root := xixo.NewXMLElement()
+	root.Name = parentTag
 	root.InnerText = "Hello"
-	root.AddAttribut("foo", "bar")
+	root.AddAttribute("foo", "bar")
 
 	expected := "<root foo=\"bar\">Hello</root>"
 	assert.Equal(t, expected, root.String())
@@ -185,15 +191,15 @@ func TestAddAttributsShouldInOutputWithString(t *testing.T) {
 func TestEditAttributsShouldInOutputWithString(t *testing.T) {
 	t.Parallel()
 
-	var root *xixo.XMLElement
-	root = xixo.NewXMLElement()
-	root.Name = "root"
+	root := xixo.NewXMLElement()
+	root.Name = parentTag
 	root.InnerText = "Hello"
-	root.AddAttribut("foo", "bar")
+	root.AddAttribute("foo", "bar")
 
 	expected := "<root foo=\"bar\">Hello</root>"
 	assert.Equal(t, expected, root.String())
-	root.AddAttribut("foo", "bas")
+	root.AddAttribute("foo", "bas")
+
 	expected = "<root foo=\"bas\">Hello</root>"
 	assert.Equal(t, expected, root.String())
 }

--- a/pkg/xixo/element_test.go
+++ b/pkg/xixo/element_test.go
@@ -120,3 +120,17 @@ func TestAddAttributsShouldSaved(t *testing.T) {
 	expected := map[string]string{"foo": "bar"}
 	assert.Equal(t, root.Attrs, expected)
 }
+
+func TestAddAttributsShouldInOutputWithString(t *testing.T) {
+	t.Parallel()
+
+	var root *xixo.XMLElement
+	name := "root"
+	root = xixo.NewXMLElement()
+	root.Name = name
+	root.InnerText = "Hello"
+	root.AddAttribut("foo", "bar")
+
+	expected := "<root foo=\"bar\">Hello</root>"
+	assert.Equal(t, expected, root.String())
+}

--- a/pkg/xixo/element_test.go
+++ b/pkg/xixo/element_test.go
@@ -33,6 +33,54 @@ func createTree() *xixo.XMLElement {
 	return root
 }
 
+func createTreeWithAttribut() *xixo.XMLElement {
+	rootXML := `
+	<root>
+		<element1 age="22">Hello world !</element1>
+		<element2>Contenu2 </element2>
+	</root>`
+
+	var root *xixo.XMLElement
+
+	parser := xixo.NewXMLParser(bytes.NewBufferString(rootXML), io.Discard).EnableXpath()
+	parser.RegisterCallback("root", func(x *xixo.XMLElement) (*xixo.XMLElement, error) {
+		root = x
+
+		return x, nil
+	})
+
+	err := parser.Stream()
+	if err != nil {
+		return nil
+	}
+
+	return root
+}
+
+func createTreeWithAttributParent() *xixo.XMLElement {
+	rootXML := `
+	<root type="foo">
+		<element1 age="22" sex="male">Hello world !</element1>
+		<element2>Contenu2 </element2>
+	</root>`
+
+	var root *xixo.XMLElement
+
+	parser := xixo.NewXMLParser(bytes.NewBufferString(rootXML), io.Discard).EnableXpath()
+	parser.RegisterCallback("root", func(x *xixo.XMLElement) (*xixo.XMLElement, error) {
+		root = x
+
+		return x, nil
+	})
+
+	err := parser.Stream()
+	if err != nil {
+		return nil
+	}
+
+	return root
+}
+
 func TestElementStringShouldReturnXML(t *testing.T) {
 	t.Parallel()
 
@@ -125,12 +173,27 @@ func TestAddAttributsShouldInOutputWithString(t *testing.T) {
 	t.Parallel()
 
 	var root *xixo.XMLElement
-	name := "root"
 	root = xixo.NewXMLElement()
-	root.Name = name
+	root.Name = "root"
 	root.InnerText = "Hello"
 	root.AddAttribut("foo", "bar")
 
 	expected := "<root foo=\"bar\">Hello</root>"
+	assert.Equal(t, expected, root.String())
+}
+
+func TestEditAttributsShouldInOutputWithString(t *testing.T) {
+	t.Parallel()
+
+	var root *xixo.XMLElement
+	root = xixo.NewXMLElement()
+	root.Name = "root"
+	root.InnerText = "Hello"
+	root.AddAttribut("foo", "bar")
+
+	expected := "<root foo=\"bar\">Hello</root>"
+	assert.Equal(t, expected, root.String())
+	root.AddAttribut("foo", "bas")
+	expected = "<root foo=\"bas\">Hello</root>"
 	assert.Equal(t, expected, root.String())
 }

--- a/pkg/xixo/parser.go
+++ b/pkg/xixo/parser.go
@@ -467,12 +467,7 @@ search_close_tag:
 		if x.isWS(cur) {
 			continue
 		}
-
 		if cur == '=' {
-			if result.Attrs == nil {
-				result.Attrs = map[string]string{}
-			}
-
 			cur, err = x.readByte()
 
 			if err != nil {
@@ -488,10 +483,10 @@ search_close_tag:
 			if err != nil {
 				return nil, false, x.defaultError()
 			}
-			result.Attrs[attr] = attrVal
-			if x.xpathEnabled {
-				result.attrs = append(result.attrs, &xmlAttr{name: attr, value: attrVal})
-			}
+			result.AddAttribute(attr, attrVal)
+			// if x.xpathEnabled {
+			// 	result.attrs = append(result.attrs, &xmlAttr{name: attr, value: attrVal})
+			// }
 			x.scratch.reset()
 
 			continue

--- a/pkg/xixo/parser_test.go
+++ b/pkg/xixo/parser_test.go
@@ -142,11 +142,49 @@ func TestAttributsShouldSavedAfterParser(t *testing.T) {
 	err := parser.Stream()
 	assert.Nil(t, err)
 
-	// Résultat XML attendu avec le contenu modifié et attributs restés
+	// Résultat XML attendu avec le contenu modifié et attributes restés
 	expectedResultXML := `
 	<root name="start">
 		<name age="12" gender="male">ContenuModifie</name>
 	</root>`
+
+	// Vérifiez si le résultat XML correspond à l'attendu
+	resultXML := resultXMLBuffer.String()
+
+	if resultXML != expectedResultXML {
+		t.Errorf("Le résultat XML ne correspond pas à l'attendu.\nAttendu:\n%s\nObtenu:\n%s", expectedResultXML, resultXML)
+	}
+}
+
+func TestModifyAttributsWithMapCallback(t *testing.T) {
+	t.Parallel()
+	// Fichier XML en entrée
+	inputXML := `
+	<root>
+		<element1 age="22" sex="male">Hello world!</element1>
+		<element2>Contenu2 !</element2>
+	</root>`
+
+	// Lisez les résultats du canal et construisez le XML résultant
+	var resultXMLBuffer bytes.Buffer
+
+	// Créez un bufio.Reader à partir du XML en entrée
+	reader := bytes.NewBufferString(inputXML)
+
+	// Créez une nouvelle instance du parser XML avec la fonction de rappel
+	parser := xixo.NewXMLParser(reader, &resultXMLBuffer).EnableXpath()
+	parser.RegisterMapCallback("root", mapCallbackAttributsWithParent)
+
+	// Créez un canal pour collecter les résultats du parser
+	err := parser.Stream()
+	assert.Nil(t, err)
+
+	// Résultat XML attendu avec le contenu modifié
+	expectedResultXML := `
+	<root type="bar">
+  <element1 age="50" sex="male">newChildContent</element1>
+  <element2 age="25">Contenu2 !</element2>
+</root>`
 
 	// Vérifiez si le résultat XML correspond à l'attendu
 	resultXML := resultXMLBuffer.String()

--- a/pkg/xixo/parser_test.go
+++ b/pkg/xixo/parser_test.go
@@ -120,3 +120,75 @@ func TestModifyElementWrappedWithTextWithCallback(t *testing.T) {
 		t.Errorf("Le résultat XML ne correspond pas à l'attendu.\nAttendu:\n%s\nObtenu:\n%s", expectedResultXML, resultXML)
 	}
 }
+
+func TestAttributsShouldSavedAfterParser(t *testing.T) {
+	t.Parallel()
+	// Fichier XML en entrée
+	inputXML := `
+	<root>
+		<name age="12" gender="male">Hello</name>
+	</root>`
+
+	// Lisez les résultats du canal et construisez le XML résultant
+	var resultXMLBuffer bytes.Buffer
+
+	// Créez un bufio.Reader à partir du XML en entrée
+	reader := bytes.NewBufferString(inputXML)
+
+	// Créez une nouvelle instance du parser XML avec la fonction de rappel et xPath
+	parser := xixo.NewXMLParser(reader, &resultXMLBuffer).EnableXpath()
+	parser.RegisterCallback("name", modifyElement1Content)
+	// Créez un canal pour collecter les résultats du parser
+	err := parser.Stream()
+	assert.Nil(t, err)
+
+	// Résultat XML attendu avec le contenu modifié et attributs restés
+	expectedResultXML := `
+	<root>
+		<name age="12" gender="male">ContenuModifie</name>
+	</root>`
+
+	// Vérifiez si le résultat XML correspond à l'attendu
+	resultXML := resultXMLBuffer.String()
+
+	if resultXML != expectedResultXML {
+		t.Errorf("Le résultat XML ne correspond pas à l'attendu.\nAttendu:\n%s\nObtenu:\n%s", expectedResultXML, resultXML)
+	}
+}
+
+// func TestTagWithSlashShouldSaved(t *testing.T) {
+// 	t.Parallel()
+// 	// Fichier XML en entrée
+// 	inputXML := `
+// 	<root>
+// 		<name age="12" gender="male">Hello</name>
+// 		<name />Hello</name />
+// 	</root>`
+
+// 	// Lisez les résultats du canal et construisez le XML résultant
+// 	var resultXMLBuffer bytes.Buffer
+
+// 	// Créez un bufio.Reader à partir du XML en entrée
+// 	reader := bytes.NewBufferString(inputXML)
+
+// 	// Créez une nouvelle instance du parser XML avec la fonction de rappel et xPath
+// 	parser := xixo.NewXMLParser(reader, &resultXMLBuffer).EnableXpath()
+// 	parser.RegisterCallback("name", modifyElement1Content)
+// 	// Créez un canal pour collecter les résultats du parser
+// 	err := parser.Stream()
+// 	assert.Nil(t, err)
+
+// 	// Résultat XML attendu avec le contenu modifié et attributs restés
+// 	expectedResultXML := `
+// 	<root>
+// 		<name age="12" gender="male">ContenuModifie</name>
+// 		<name />Hello</name />
+// 	</root>`
+
+// 	// Vérifiez si le résultat XML correspond à l'attendu
+// 	resultXML := resultXMLBuffer.String()
+
+// 	if resultXML != expectedResultXML {
+// 		t.Errorf("Le résultat XML ne correspond pas à l'attendu.\nAttendu:\n%s\nObtenu:\n%s", expectedResultXML, resultXML)
+// 	}
+// }

--- a/pkg/xixo/parser_test.go
+++ b/pkg/xixo/parser_test.go
@@ -125,7 +125,7 @@ func TestAttributsShouldSavedAfterParser(t *testing.T) {
 	t.Parallel()
 	// Fichier XML en entrée
 	inputXML := `
-	<root>
+	<root name="start">
 		<name age="12" gender="male">Hello</name>
 	</root>`
 
@@ -144,7 +144,7 @@ func TestAttributsShouldSavedAfterParser(t *testing.T) {
 
 	// Résultat XML attendu avec le contenu modifié et attributs restés
 	expectedResultXML := `
-	<root>
+	<root name="start">
 		<name age="12" gender="male">ContenuModifie</name>
 	</root>`
 
@@ -155,40 +155,3 @@ func TestAttributsShouldSavedAfterParser(t *testing.T) {
 		t.Errorf("Le résultat XML ne correspond pas à l'attendu.\nAttendu:\n%s\nObtenu:\n%s", expectedResultXML, resultXML)
 	}
 }
-
-// func TestTagWithSlashShouldSaved(t *testing.T) {
-// 	t.Parallel()
-// 	// Fichier XML en entrée
-// 	inputXML := `
-// 	<root>
-// 		<name age="12" gender="male">Hello</name>
-// 		<name />Hello</name />
-// 	</root>`
-
-// 	// Lisez les résultats du canal et construisez le XML résultant
-// 	var resultXMLBuffer bytes.Buffer
-
-// 	// Créez un bufio.Reader à partir du XML en entrée
-// 	reader := bytes.NewBufferString(inputXML)
-
-// 	// Créez une nouvelle instance du parser XML avec la fonction de rappel et xPath
-// 	parser := xixo.NewXMLParser(reader, &resultXMLBuffer).EnableXpath()
-// 	parser.RegisterCallback("name", modifyElement1Content)
-// 	// Créez un canal pour collecter les résultats du parser
-// 	err := parser.Stream()
-// 	assert.Nil(t, err)
-
-// 	// Résultat XML attendu avec le contenu modifié et attributs restés
-// 	expectedResultXML := `
-// 	<root>
-// 		<name age="12" gender="male">ContenuModifie</name>
-// 		<name />Hello</name />
-// 	</root>`
-
-// 	// Vérifiez si le résultat XML correspond à l'attendu
-// 	resultXML := resultXMLBuffer.String()
-
-// 	if resultXML != expectedResultXML {
-// 		t.Errorf("Le résultat XML ne correspond pas à l'attendu.\nAttendu:\n%s\nObtenu:\n%s", expectedResultXML, resultXML)
-// 	}
-// }

--- a/test/data/exemple.xml
+++ b/test/data/exemple.xml
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<taxes>
+    <account location="New York">
+        <name gender="male" age="23">Doe John</name>
+        <account_number>12345</account_number>
+    </account>
+</taxes>

--- a/test/data/exemple_expected.jsonl
+++ b/test/data/exemple_expected.jsonl
@@ -1,0 +1,1 @@
+{"@location":"New York", "name":"Doe John", "name@gender":"male", "age":"23", "account_number":12345}


### PR DESCRIPTION
Ajouter un slice de string `AttrKeys` dans struct `XMLElement` pour garder l'ordre des attributs.
Utilise `Attrs` au lieu de `attrs` pour stocker les attributs. (attrs est pour v3 quand Xpath est intégré).
 Ajouter function `AddAttribute()` pour gérer le cas quand `Attrs` est `nil`, aussi pour stoker et modifier `Attrs` et `AttrKeys`.
Ajouter function `extractParentAttributes()` pour gérer les attributs de balise parent. ( @nomDeAttribut)
Ajouter function `extractChildAttributes()` pour gérer les attributs de balise enfant. ( nomDeBalise@nomDeAttribut)
Ajouter un constructor `NewXMLElement()` pour `XMLElement.`
Ajouter les tests pour test les fonctions et résultats de output.
